### PR TITLE
Don't stub functions from WASI SDK 15.0

### DIFF
--- a/include/sys/socket.h
+++ b/include/sys/socket.h
@@ -139,7 +139,9 @@ int socket(int domain, int type, int protocol);
 int connect(int sockfd, const struct sockaddr *addr, socklen_t addrlen);
 int bind(int sockfd, const struct sockaddr *addr, socklen_t addrlen);
 int listen(int sockfd, int backlog);
+#ifdef WASI_SDK_14
 int accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen);
+#endif
 int socketpair(int domain, int type, int protocol, int sv[2]);
 
 ssize_t send(int sockfd, const void *buf, size_t len, int flags);

--- a/include/time.h
+++ b/include/time.h
@@ -6,7 +6,9 @@
 
 typedef long long clock_t;
 
+#ifdef WASI_SDK_14
 int utimes(const char *filename, const struct timeval times[2]);
+#endif
 clock_t clock(void);
 
 #endif

--- a/src/socket.c
+++ b/src/socket.c
@@ -25,10 +25,12 @@ int listen(int sockfd, int backlog) {
     return -1;
 }
 
+#if WASI_SDK_14
 int accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen) {
     (void)unimplemented(ENOTSUP);
     return -1;
 }
+#endif
 
 int socketpair(int domain, int type, int protocol, int sv[2]) {
     (void)unimplemented(ENOTSUP);

--- a/src/socket.c
+++ b/src/socket.c
@@ -25,7 +25,7 @@ int listen(int sockfd, int backlog) {
     return -1;
 }
 
-#if WASI_SDK_14
+#ifdef WASI_SDK_14
 int accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen) {
     (void)unimplemented(ENOTSUP);
     return -1;

--- a/src/time.c
+++ b/src/time.c
@@ -4,10 +4,12 @@
 #include <unimplemented.h>
 
 
+#ifdef WASI_SDK_14
 int utimes(const char* filename, const struct timeval times[2]) {
     (void)unimplemented(ENOTSUP);
     return -1;
 }
+#endif
 
 clock_t clock(void) {
     (void)unimplemented(ENOTSUP);


### PR DESCRIPTION
[WASI SDK 15.0](https://github.com/WebAssembly/wasi-sdk/releases/tag/wasi-sdk-15)
added support for ``accept`` and ``utimes``.

Fixes: #2
Signed-off-by: Christian Heimes <christian@python.org>